### PR TITLE
add Atila to new Scholarships and grants category

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -74,6 +74,7 @@ Goto [BSC Developer Ecosystem](https://github.com/binance-chain/bsc-ecosystem/bl
 
 | Components | Existing projects | Potentially interesting projects
 |-|-|-
+| Scholarships and Grants | [Atila](https://atila.ca/)|
 | Scalable Transactions | | roll-ups, DAG-based consensus mechanisms, side chains |
 | ZKP |  | [zkswap](https://zks.org/), [loopring](https://loopring.org/#/)
 | Identity/DID | [Ontology](https://ont.io/) | [Blockpass](https://blockpass.org/), [Bloom](https://bloom.co/), [Civic](https://www.civic.com/)


### PR DESCRIPTION
[Atila](https://atila.ca) is a platform that allows people to get scholarships and grants using crypto and it supports BSC and BNB Coin. Created a new category called Scholarships and Grants.

See: 
- https://atila.ca/crypto
- https://www.youtube.com/watch?v=rsE-PFz5vTE